### PR TITLE
[BUGFIX] Fix Embroider by using a global variable 

### DIFF
--- a/lib/classic-decorator-transform.js
+++ b/lib/classic-decorator-transform.js
@@ -1,4 +1,7 @@
 /* globals module */
+'use strict';
+
+const IS_EMBER_CLASSIC_DECORATORS = /^ember-classic-decorators$/i;
 
 module.exports = function(babel) {
   const { types: t } = babel;
@@ -7,6 +10,28 @@ module.exports = function(babel) {
     name: 'classic-decorator-transform',
 
     visitor: {
+      // this will 1. remove `import X from 'ember-classic-decorator';
+      // and then 2. will replace it with `const X = __EMBER_CLASSIC_DECORATOR`;
+      ImportDeclaration(path) {
+        const node = path.node;
+        const specifier = node.specifiers[0];
+        const moduleName = node.source.value;
+
+        if (specifier.type !== 'ImportDefaultSpecifier') {
+          return;
+          // maybe error, as we don't support this;
+        }
+
+        if (!IS_EMBER_CLASSIC_DECORATORS.test(moduleName)) { return; }
+
+        path.replaceWith(t.variableDeclaration('const', [
+          t.variableDeclarator(
+            t.identifier(specifier.local.name),
+            t.identifier('__EMBER_CLASSIC_DECORATOR')
+          ),
+        ]));
+      },
+
       ClassDeclaration(path) {
         if (path.node.id) {
           path.insertAfter(

--- a/lib/classic-decorator-transform.js
+++ b/lib/classic-decorator-transform.js
@@ -1,7 +1,7 @@
 /* globals module */
 'use strict';
 
-const IS_EMBER_CLASSIC_DECORATORS = /^ember-classic-decorators$/i;
+const IS_EMBER_CLASSIC_DECORATORS = /^ember-classic-decorator$/i;
 
 module.exports = function(babel) {
   const { types: t } = babel;
@@ -17,19 +17,24 @@ module.exports = function(babel) {
         const specifier = node.specifiers[0];
         const moduleName = node.source.value;
 
-        if (specifier.type !== 'ImportDefaultSpecifier') {
+        if (!IS_EMBER_CLASSIC_DECORATORS.test(moduleName)) {
           return;
-          // maybe error, as we don't support this;
         }
 
-        if (!IS_EMBER_CLASSIC_DECORATORS.test(moduleName)) { return; }
+        if (specifier.type !== 'ImportDefaultSpecifier') {
+          throw new Error(
+            "you must import the default value from `ember-classic-decorator`: import classic from 'ember-classic-decorator';"
+          );
+        }
 
-        path.replaceWith(t.variableDeclaration('const', [
-          t.variableDeclarator(
-            t.identifier(specifier.local.name),
-            t.identifier('__EMBER_CLASSIC_DECORATOR')
-          ),
-        ]));
+        path.replaceWith(
+          t.variableDeclaration('const', [
+            t.variableDeclarator(
+              t.identifier(specifier.local.name),
+              t.identifier('__EMBER_CLASSIC_DECORATOR')
+            ),
+          ])
+        );
       },
 
       ClassDeclaration(path) {

--- a/vendor/classic-decorator/index.js
+++ b/vendor/classic-decorator/index.js
@@ -1,14 +1,14 @@
 'use strict';
 
 /* globals Ember, define */
-(function() {
+(function(global) {
   var OWN_CLASSES = new WeakMap();
   var HAS_CONSTRUCTOR = new WeakMap();
   var IS_CLASSIC = new WeakMap();
   var BASE_CLASSES = new WeakMap();
   var IS_PERMA_CLASSIC = new WeakMap();
-  window.__CLASSIC_HAS_CONSTRUCTOR__ = HAS_CONSTRUCTOR;
-  window.__CLASSIC_OWN_CLASSES__ = OWN_CLASSES;
+  global.__CLASSIC_HAS_CONSTRUCTOR__ = HAS_CONSTRUCTOR;
+  global.__CLASSIC_OWN_CLASSES__ = OWN_CLASSES;
   IS_PERMA_CLASSIC.set(Ember.Object, true);
   IS_PERMA_CLASSIC.set(Ember.Component, true);
   IS_PERMA_CLASSIC.set(Ember.Controller, false);
@@ -123,14 +123,9 @@
       return ret;
     },
   });
-  define('ember-classic-decorator', ['exports'], function(exports) {
-    Object.defineProperty(exports, '__esModule', {
-      value: true,
-    });
 
-    exports.default = function classic(target) {
-      IS_CLASSIC.set(target, true);
-      return target;
-    };
-  });
-})();
+  global.__EMBER_CLASSIC_DECORATOR = function classic(target) {
+    IS_CLASSIC.set(target, true);
+    return target;
+  }
+})(window);


### PR DESCRIPTION
This isn't working/tested etc, just pushing to share the idea. Will resume likely tomorrow afternoon.

But TL;DR the idea is to make this function how `import Object from '@ember/object'` functions. 

So we would take user code:
```js
import classic from 'ember-classic-decorator';

export default @classic class Apple { };
```

And transform it into:

```js
const classic = __EMBER_CLASSIC_DECORATOR;
export default @classic class Apple { };
```

And also change our vendor imported script from an AMD module, to a global which exposes `__EMBER_CLASSIC_DECORATOR`. 

This should ensure we don't leave unresolvable module imports around.

---

- [x] confirm the idea will be ok with @pzuraq 
- [ ] write node-tests for the babel transform
- [x] make work
- [x] cleanup